### PR TITLE
Add retry with backoff on 429 rate limit responses

### DIFF
--- a/src/OctanyClient.php
+++ b/src/OctanyClient.php
@@ -3,6 +3,7 @@
 namespace Octany;
 
 use Exception;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -59,7 +60,7 @@ class OctanyClient
         return Http::withHeaders([
             'X-API-Key' => $this->key,
         ])->retry(3, function ($attempt, $exception) {
-            if ($exception instanceof \Illuminate\Http\Client\RequestException) {
+            if ($exception instanceof RequestException) {
                 $retryAfter = $exception->response->header('Retry-After');
 
                 if ($retryAfter) {
@@ -69,7 +70,7 @@ class OctanyClient
 
             return $attempt * 1000;
         }, function ($exception) {
-            return $exception instanceof \Illuminate\Http\Client\RequestException
+            return $exception instanceof RequestException
                 && $exception->response->status() === 429;
         })->withOptions([
             'on_stats' => function ($stats) {

--- a/src/OctanyClient.php
+++ b/src/OctanyClient.php
@@ -37,16 +37,7 @@ class OctanyClient
     {
         $parameters['locale'] = Arr::get($parameters, 'locale', app()->getLocale());
 
-        $client = Http::withHeaders([
-            'X-API-Key' => $this->key,
-        ])->withOptions([
-            'on_stats' => function ($stats) {
-                if (config('app.debug') && config('octany-php.log.requests')) {
-                    Log::channel(config('octany-php.log.channel'))
-                        ->debug('[HTTP DEBUG] '.Curl::fromRequest($stats->getRequest()));
-                }
-            },
-        ]);
+        $client = $this->httpClient();
 
         $this->latestResponse = $client->get($this->url($endpoint), $parameters);
 
@@ -57,12 +48,37 @@ class OctanyClient
     {
         $parameters['locale'] = Arr::get($parameters, 'locale', app()->getLocale());
 
-        $this->latestResponse =
-            Http::withHeaders([
-                'X-API-Key' => $this->key,
-            ])->post($this->url($endpoint), $parameters);
+        $this->latestResponse = $this->httpClient()
+            ->post($this->url($endpoint), $parameters);
 
         return $this->response();
+    }
+
+    private function httpClient()
+    {
+        return Http::withHeaders([
+            'X-API-Key' => $this->key,
+        ])->retry(3, function ($attempt, $exception) {
+            if ($exception instanceof \Illuminate\Http\Client\RequestException) {
+                $retryAfter = $exception->response->header('Retry-After');
+
+                if ($retryAfter) {
+                    return (int) $retryAfter * 1000;
+                }
+            }
+
+            return $attempt * 1000;
+        }, function ($exception) {
+            return $exception instanceof \Illuminate\Http\Client\RequestException
+                && $exception->response->status() === 429;
+        })->withOptions([
+            'on_stats' => function ($stats) {
+                if (config('app.debug') && config('octany-php.log.requests')) {
+                    Log::channel(config('octany-php.log.channel'))
+                        ->debug('[HTTP DEBUG] '.Curl::fromRequest($stats->getRequest()));
+                }
+            },
+        ]);
     }
 
     private function url($endpoint)


### PR DESCRIPTION
## Summary
- Extracts shared `httpClient()` method used by both `get()` and `post()`
- Adds `retry(3, ...)` that only triggers on 429 responses
- Respects the `Retry-After` header from Laravel's `ThrottleRequests` middleware, falling back to incremental backoff (`attempt * 1000ms`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)