### PR TITLE
Address PHP SDK feedback from Samtal integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,152 @@
 [![GitHub Tests Action Status](https://img.shields.io/github/workflow/status/octany/octany-php/run-tests?label=tests)](https://github.com/octany/octany-php/actions?query=workflow%3Arun-tests+branch%3Amain)
 [![GitHub Code Style Action Status](https://img.shields.io/github/workflow/status/octany/octany-php/Fix%20PHP%20code%20style%20issues?label=code%20style)](https://github.com/octany/octany-php/actions?query=workflow%3A"Fix+PHP+code+style+issues"+branch%3Amain)
 
-This package is under development
+This package is under development.
 
 ## Installation
-
-You can install the package via composer:
 
 ```bash
 composer require octany/octany-php
 ```
 
+## Configuration
+
+Publish the config file (optional — defaults read from env):
+
+```bash
+php artisan vendor:publish --tag=config --provider="Octany\Providers\OctanyServiceProvider"
+```
+
+Then set the following in `.env`:
+
+```
+OCTANY_ACCOUNT=your-account-uuid
+OCTANY_API_KEY=your-api-key
+OCTANY_API_URL=                       # optional, defaults to https://app.octany.com
+OCTANY_WEBHOOK_SECRET=                # optional, used by Octany\Webhook::verify()
+```
+
+`config/octany-php.php` also exposes an `http_options` array which is passed
+through to Laravel's HTTP client via `withOptions()` — useful for local dev
+against self-signed certificates (e.g. `'verify' => false`).
+
 ## Usage
 
+The service provider binds `Octany\OctanyClient` as a singleton, so you can
+type-hint it or use the `Octany` facade:
+
 ```php
-$client = new Octany\OctanyClient();
+use Octany\Facades\Octany;
+
+$subscription = Octany::subscriptions()->find(['reference_id' => $user->id]);
+```
+
+Or resolve the client directly:
+
+```php
+use Octany\OctanyClient;
+
+$client = app(OctanyClient::class);
 $subscriptions = $client->subscriptions()->all();
 ```
 
+If you'd rather construct the client manually:
+
+```php
+$client = new OctanyClient(
+    config('octany-php.account'),
+    config('octany-php.api_key'),
+    [
+        'domain' => config('octany-php.api_url'),
+        'http_options' => ['verify' => false], // dev-only
+    ],
+);
+```
+
+## Method reference
+
+### `subscriptions()`
+
+| Method                                                                              | Description                                                  |
+|-------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `all()`                                                                             | List all subscriptions for the account.                      |
+| `find(array $filters)`                                                              | Find the first subscription matching the given filters.      |
+| `order($subscriptionId, $amount, $description, $productId, array $options = [])`    | Create a one-off order against an existing subscription.     |
+| `orders($subscriptionId, array $filters = [])`                                      | List orders for a subscription.                              |
+| `createFromSubscriptionBillingMethod($subscriptionId, $productId, $options = [])`   | Start a new subscription using an existing billing method.   |
+
+Filter keys supported by `find()` include `reference_id`, `customer_id`,
+`status`, and `product_id`. `find()` returns the first match, or an empty
+array when no match is found.
+
+## Webhooks
+
+The package ships a small helper for verifying the `Octany-Signature` HMAC
+header on incoming webhooks:
+
+```php
+use Octany\Webhook;
+use Octany\Exceptions\OctanyInvalidSignatureException;
+
+Route::post('/octany/webhook', function (Request $request) {
+    try {
+        $payload = Webhook::verify($request, config('octany-php.webhook_secret'));
+    } catch (OctanyInvalidSignatureException $e) {
+        abort(401);
+    }
+
+    // dispatch jobs, sync local state, etc.
+});
+```
+
+`Webhook::verify()` returns the decoded JSON payload as an array, or throws
+`OctanyInvalidSignatureException` on a bad/missing signature. The constant-time
+comparison and signature header name (`Octany-Signature`) are handled for you.
+
+## Exception handling
+
+API errors throw typed exceptions, all extending `Octany\Exceptions\OctanyException`:
+
+| Status      | Exception                                              |
+|-------------|--------------------------------------------------------|
+| 401, 403    | `Octany\Exceptions\OctanyAuthenticationException`      |
+| 404         | `Octany\Exceptions\OctanyNotFoundException`            |
+| 422         | `Octany\Exceptions\OctanyValidationException`          |
+| 429         | `Octany\Exceptions\OctanyRateLimitException`           |
+| other       | `Octany\Exceptions\OctanyException`                    |
+
+Each exception exposes the HTTP status (`$e->statusCode()`) and the raw
+response body (`$e->responseBody()`).
+
+```php
+use Octany\Exceptions\OctanyNotFoundException;
+use Octany\Exceptions\OctanyValidationException;
+
+try {
+    $client->subscriptions()->find(['reference_id' => $user->id]);
+} catch (OctanyValidationException $e) {
+    Log::warning('Octany rejected request', ['body' => $e->responseBody()]);
+} catch (OctanyNotFoundException $e) {
+    // ...
+}
+```
+
 ## Testing
+
+Because the SDK uses Laravel's HTTP client under the hood, you can fake API
+responses with `Http::fake()` in your application's test suite:
+
+```php
+use Illuminate\Support\Facades\Http;
+
+Http::fake([
+    '*/api/*/subscriptions*' => Http::response([
+        'data' => [['id' => 76963688, 'status' => 'active']],
+    ]),
+]);
+```
+
+Run the package's own test suite with:
 
 ```bash
 composer test

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,10 @@
         "laravel": {
             "providers": [
                 "Octany\\Providers\\OctanyServiceProvider"
-            ]
+            ],
+            "aliases": {
+                "Octany": "Octany\\Facades\\Octany"
+            }
         }
     },
     "minimum-stability": "dev",

--- a/config/octany-php.php
+++ b/config/octany-php.php
@@ -1,6 +1,20 @@
 <?php
 
 return [
+    'account' => env('OCTANY_ACCOUNT'),
+
+    'api_key' => env('OCTANY_API_KEY'),
+
+    'api_url' => env('OCTANY_API_URL'),
+
+    'webhook_secret' => env('OCTANY_WEBHOOK_SECRET'),
+
+    'http_options' => [
+        // Passed straight to Laravel's HTTP client via withOptions().
+        // Useful for local dev against self-signed certs:
+        // 'verify' => env('OCTANY_VERIFY_SSL', true),
+    ],
+
     'log' => [
         'requests' => true,
         'channel' => env('LOG_CHANNEL'),

--- a/src/Exceptions/OctanyAuthenticationException.php
+++ b/src/Exceptions/OctanyAuthenticationException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Octany\Exceptions;
+
+class OctanyAuthenticationException extends OctanyException
+{
+}

--- a/src/Exceptions/OctanyAuthenticationException.php
+++ b/src/Exceptions/OctanyAuthenticationException.php
@@ -2,6 +2,4 @@
 
 namespace Octany\Exceptions;
 
-class OctanyAuthenticationException extends OctanyException
-{
-}
+class OctanyAuthenticationException extends OctanyException {}

--- a/src/Exceptions/OctanyException.php
+++ b/src/Exceptions/OctanyException.php
@@ -11,7 +11,7 @@ class OctanyException extends Exception
 
     protected $responseBody;
 
-    public function __construct($message = '', $statusCode = 0, $responseBody = null, Throwable $previous = null)
+    public function __construct($message = '', $statusCode = 0, $responseBody = null, ?Throwable $previous = null)
     {
         parent::__construct($message, $statusCode, $previous);
 

--- a/src/Exceptions/OctanyException.php
+++ b/src/Exceptions/OctanyException.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Octany\Exceptions;
+
+use Exception;
+use Throwable;
+
+class OctanyException extends Exception
+{
+    protected $statusCode;
+
+    protected $responseBody;
+
+    public function __construct($message = '', $statusCode = 0, $responseBody = null, Throwable $previous = null)
+    {
+        parent::__construct($message, $statusCode, $previous);
+
+        $this->statusCode = $statusCode;
+        $this->responseBody = $responseBody;
+    }
+
+    public function statusCode()
+    {
+        return $this->statusCode;
+    }
+
+    public function responseBody()
+    {
+        return $this->responseBody;
+    }
+}

--- a/src/Exceptions/OctanyInvalidSignatureException.php
+++ b/src/Exceptions/OctanyInvalidSignatureException.php
@@ -2,6 +2,4 @@
 
 namespace Octany\Exceptions;
 
-class OctanyInvalidSignatureException extends OctanyException
-{
-}
+class OctanyInvalidSignatureException extends OctanyException {}

--- a/src/Exceptions/OctanyInvalidSignatureException.php
+++ b/src/Exceptions/OctanyInvalidSignatureException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Octany\Exceptions;
+
+class OctanyInvalidSignatureException extends OctanyException
+{
+}

--- a/src/Exceptions/OctanyNotFoundException.php
+++ b/src/Exceptions/OctanyNotFoundException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Octany\Exceptions;
+
+class OctanyNotFoundException extends OctanyException
+{
+}

--- a/src/Exceptions/OctanyNotFoundException.php
+++ b/src/Exceptions/OctanyNotFoundException.php
@@ -2,6 +2,4 @@
 
 namespace Octany\Exceptions;
 
-class OctanyNotFoundException extends OctanyException
-{
-}
+class OctanyNotFoundException extends OctanyException {}

--- a/src/Exceptions/OctanyRateLimitException.php
+++ b/src/Exceptions/OctanyRateLimitException.php
@@ -2,6 +2,4 @@
 
 namespace Octany\Exceptions;
 
-class OctanyRateLimitException extends OctanyException
-{
-}
+class OctanyRateLimitException extends OctanyException {}

--- a/src/Exceptions/OctanyRateLimitException.php
+++ b/src/Exceptions/OctanyRateLimitException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Octany\Exceptions;
+
+class OctanyRateLimitException extends OctanyException
+{
+}

--- a/src/Exceptions/OctanyValidationException.php
+++ b/src/Exceptions/OctanyValidationException.php
@@ -2,6 +2,4 @@
 
 namespace Octany\Exceptions;
 
-class OctanyValidationException extends OctanyException
-{
-}
+class OctanyValidationException extends OctanyException {}

--- a/src/Exceptions/OctanyValidationException.php
+++ b/src/Exceptions/OctanyValidationException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Octany\Exceptions;
+
+class OctanyValidationException extends OctanyException
+{
+}

--- a/src/Facades/Octany.php
+++ b/src/Facades/Octany.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Octany\Facades;
+
+use Illuminate\Support\Facades\Facade;
+use Octany\OctanyClient;
+
+/**
+ * @method static \Octany\Subscription subscriptions()
+ * @method static array get(string $endpoint, array $parameters = [])
+ * @method static array post(string $endpoint, array $parameters = [])
+ *
+ * @see \Octany\OctanyClient
+ */
+class Octany extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return OctanyClient::class;
+    }
+}

--- a/src/Facades/Octany.php
+++ b/src/Facades/Octany.php
@@ -10,7 +10,7 @@ use Octany\OctanyClient;
  * @method static array get(string $endpoint, array $parameters = [])
  * @method static array post(string $endpoint, array $parameters = [])
  *
- * @see \Octany\OctanyClient
+ * @see OctanyClient
  */
 class Octany extends Facade
 {

--- a/src/OctanyClient.php
+++ b/src/OctanyClient.php
@@ -2,11 +2,15 @@
 
 namespace Octany;
 
-use Exception;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Octany\Exceptions\OctanyAuthenticationException;
+use Octany\Exceptions\OctanyException;
+use Octany\Exceptions\OctanyNotFoundException;
+use Octany\Exceptions\OctanyRateLimitException;
+use Octany\Exceptions\OctanyValidationException;
 use Octany\Utils\Curl;
 
 class OctanyClient
@@ -19,6 +23,8 @@ class OctanyClient
 
     private $latestResponse;
 
+    private $httpOptions = [];
+
     public function __construct($accountId, $key, $options = [])
     {
         $this->accountId = $accountId;
@@ -27,6 +33,8 @@ class OctanyClient
         if ($domain = Arr::get($options, 'domain')) {
             $this->baseUrl = "$domain/api";
         }
+
+        $this->httpOptions = Arr::get($options, 'http_options', []);
     }
 
     public function subscriptions()
@@ -55,8 +63,17 @@ class OctanyClient
         return $this->response();
     }
 
-    private function httpClient()
+    protected function httpClient()
     {
+        $options = array_merge($this->httpOptions, [
+            'on_stats' => function ($stats) {
+                if (config('app.debug') && config('octany-php.log.requests')) {
+                    Log::channel(config('octany-php.log.channel'))
+                        ->debug('[HTTP DEBUG] '.Curl::fromRequest($stats->getRequest()));
+                }
+            },
+        ]);
+
         return Http::withHeaders([
             'X-API-Key' => $this->key,
         ])->retry(3, function ($attempt, $exception) {
@@ -72,14 +89,7 @@ class OctanyClient
         }, function ($exception) {
             return $exception instanceof RequestException
                 && $exception->response->status() === 429;
-        })->withOptions([
-            'on_stats' => function ($stats) {
-                if (config('app.debug') && config('octany-php.log.requests')) {
-                    Log::channel(config('octany-php.log.channel'))
-                        ->debug('[HTTP DEBUG] '.Curl::fromRequest($stats->getRequest()));
-                }
-            },
-        ]);
+        })->withOptions($options);
     }
 
     private function url($endpoint)
@@ -90,11 +100,35 @@ class OctanyClient
     protected function response()
     {
         if (! $this->latestResponse->successful()) {
-            throw new Exception(
-                $this->latestResponse->status().' – '.$this->latestResponse->serverError()
+            throw $this->makeException(
+                $this->latestResponse->status(),
+                $this->latestResponse->body()
             );
         }
 
         return $this->latestResponse->json();
+    }
+
+    protected function makeException($status, $body)
+    {
+        $message = "Octany API error ($status): $body";
+
+        if ($status === 401 || $status === 403) {
+            return new OctanyAuthenticationException($message, $status, $body);
+        }
+
+        if ($status === 404) {
+            return new OctanyNotFoundException($message, $status, $body);
+        }
+
+        if ($status === 422) {
+            return new OctanyValidationException($message, $status, $body);
+        }
+
+        if ($status === 429) {
+            return new OctanyRateLimitException($message, $status, $body);
+        }
+
+        return new OctanyException($message, $status, $body);
     }
 }

--- a/src/Providers/OctanyServiceProvider.php
+++ b/src/Providers/OctanyServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Octany\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Octany\OctanyClient;
 
 class OctanyServiceProvider extends ServiceProvider
 {
@@ -12,6 +13,26 @@ class OctanyServiceProvider extends ServiceProvider
             __DIR__.'/../../config/octany-php.php',
             'octany-php'
         );
+
+        $this->app->singleton(OctanyClient::class, function ($app) {
+            $config = $app['config']['octany-php'] ?? [];
+
+            $options = [];
+
+            if (! empty($config['api_url'])) {
+                $options['domain'] = $config['api_url'];
+            }
+
+            if (! empty($config['http_options'])) {
+                $options['http_options'] = $config['http_options'];
+            }
+
+            return new OctanyClient(
+                $config['account'] ?? null,
+                $config['api_key'] ?? null,
+                $options
+            );
+        });
     }
 
     public function boot()

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Octany;
+
+use Illuminate\Http\Request;
+use Octany\Exceptions\OctanyInvalidSignatureException;
+
+class Webhook
+{
+    const SIGNATURE_HEADER = 'Octany-Signature';
+
+    public static function verify(Request $request, $secret)
+    {
+        $payload = $request->getContent();
+        $signature = (string) $request->header(self::SIGNATURE_HEADER);
+
+        if (! self::isValidSignature($payload, $signature, $secret)) {
+            throw new OctanyInvalidSignatureException('Invalid Octany webhook signature.', 401);
+        }
+
+        $decoded = json_decode($payload, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    public static function isValidSignature($payload, $signature, $secret)
+    {
+        if ($signature === '' || $secret === null || $secret === '') {
+            return false;
+        }
+
+        $expected = hash_hmac('sha256', $payload, $secret);
+
+        return hash_equals($expected, $signature);
+    }
+}


### PR DESCRIPTION
Implements the SDK-relevant items from the Samtal integration feedback (sections §4.1–4.6 + the SDK notes in §7). Other items in the feedback (doc-site changes, hosted-checkout host, post-checkout reconciliation guide, staging port, status-state diagram, etc.) belong in the platform/docs repo and are not touched here.

## Summary

- **§4.2 — Service-provider binding + facade.** `OctanyServiceProvider` now binds `OctanyClient` as a singleton wired up from `config/octany-php.php`, and a new `Octany\Facades\Octany` facade is auto-aliased via `composer.json`. Apps no longer need a hand-written singleton in `AppServiceProvider`.
- **§4.3 — Extensible HTTP client.** `OctanyClient::httpClient()` is now `protected`, and the constructor accepts an `http_options` array that is merged into Laravel's `Http::withOptions()` call. Local dev against self-signed certs is now `'http_options' => ['verify' => false]` instead of a 75-line subclass.
- **§4.4 — Typed exceptions.** Non-2xx responses now throw `OctanyAuthenticationException` (401/403), `OctanyNotFoundException` (404), `OctanyValidationException` (422), `OctanyRateLimitException` (429), or the base `OctanyException`. All extend `OctanyException` and expose `statusCode()` / `responseBody()`.
- **§4.5 — Webhook helper.** New `Octany\Webhook::verify(Request $request, string $secret): array` performs the HMAC-SHA256 + constant-time check over the raw body and returns the decoded payload, throwing `OctanyInvalidSignatureException` on a bad/missing signature.
- **§4.1 + §4.6 — README.** Adds a method reference table for `subscriptions()`, documents the facade and webhook helper, adds an exception-handling table, and explicitly calls out that `Http::fake()` works for testing.
- **Config.** `config/octany-php.php` gains `account`, `api_key`, `api_url`, `webhook_secret`, and `http_options` keys (all env-driven).

## Not addressed here

- The `find()` returning `null` vs `[]` change (§7) — there's prior commit history (`70a2002`) that intentionally moved this from `null` to `[]`, so I left it alone and documented the current behavior in the README. Happy to revisit if you'd prefer `null`.
- Server/docs items (§1, §2, §3, §5, §6, parts of §7) live outside this repo.

## Test plan

- [ ] `composer install` in a fresh Laravel app pulls in the package and the `Octany` facade resolves without manually registering anything.
- [ ] `Octany::subscriptions()->find(['reference_id' => 1])` works using only env config (`OCTANY_ACCOUNT`, `OCTANY_API_KEY`).
- [ ] Setting `'http_options' => ['verify' => false]` lets the SDK talk to a Caddy `tls internal` staging install without subclassing.
- [ ] A 404 from the API throws `OctanyNotFoundException` whose `responseBody()` contains the API body.
- [ ] `Octany\Webhook::verify($request, $secret)` returns the decoded array on a valid signature and throws `OctanyInvalidSignatureException` on a bad one.
- [ ] `Http::fake([...])` in a host app intercepts SDK requests as documented.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M11y6Pp2TJxf3GQfLR1AVu)_